### PR TITLE
Add omnimodal engine skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project brings stable diffusion models onto web browsers. **Everything runs
 
 You are also more than welcomed to checkout [Web LLM](https://github.com/mlc-ai/web-llm) if you are interested in deploying LLM-based chat bots to browser.
 
+> **New:** the library now exposes an experimental `OmniModalMiniturbo` skeleton that sketches a 1D/2D/3D/4D diffusion interface.  The module is a placeholder for future research toward an audio‑visual, physics‑aware pipeline and does not provide real 4K@60 FPS generation.
+
 <img src="site/img/fig/browser-screenshot.png" alt="Browser screenshot"/>
 
 We have been seeing amazing progress through AI models recently. Thanks to the open-source effort, developers can now easily compose open-source models together to produce amazing tasks. Stable diffusion enables the automatic creation of photorealistic images as well as images in various styles based on text input. These models are usually big and compute-heavy, which means we have to pipe through all computation requests to (GPU) servers when developing web applications based on these models. Additionally, most of the workloads have to run on a specific type of GPUs where popular deep-learning frameworks are readily available.

--- a/web_stable_diffusion/__init__.py
+++ b/web_stable_diffusion/__init__.py
@@ -1,3 +1,12 @@
 from . import runtime
 from . import trace
 from . import utils
+from .models.miniturbo_omnimodal import OmniModalMiniturbo, MetaLogic
+
+__all__ = [
+    "runtime",
+    "trace",
+    "utils",
+    "OmniModalMiniturbo",
+    "MetaLogic",
+]

--- a/web_stable_diffusion/models/miniturbo_omnimodal.py
+++ b/web_stable_diffusion/models/miniturbo_omnimodal.py
@@ -1,0 +1,102 @@
+"""Omnimodal miniturbo engine placeholder.
+
+This module sketches a theoretical 1D/2D/3D/4D diffusion engine that
+integrates audio, images, volumetric scenes and temporal coherence.
+It follows the NeuroSymbolicEngine specification outlined by the
+user's custom instructions.
+
+The implementation is purely symbolic and does **not** provide real
+4K 60 FPS generation.  It serves as a reference for future research
+and development efforts.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Ω-Foundations: MetaLogic layers (see custom instructions)
+# ---------------------------------------------------------------------------
+@dataclass
+class MetaLogic:
+    """Meta-logic backbone consisting of lambda calculus, deduction and proofs."""
+
+    def lambda_reduce(self, expr: Any) -> Any:
+        """Placeholder lambda-calculus reduction."""
+        return expr
+
+    def deduce(self, premise: Any) -> Any:
+        """Placeholder deductive reasoning step."""
+        return premise
+
+    def prove(self, statement: Any) -> bool:
+        """Placeholder proof check returning True unconditionally."""
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Modal components
+# ---------------------------------------------------------------------------
+class Audio1DModule:
+    """1D audio generation placeholder."""
+
+    def generate(self, prompt: str) -> bytes:
+        raise NotImplementedError("Audio synthesis not implemented")
+
+
+class Image2DModule:
+    """2D image generation placeholder."""
+
+    def generate(self, prompt: str, resolution: Optional[int] = 512) -> Any:
+        raise NotImplementedError("Image synthesis not implemented")
+
+
+class Volume3DModule:
+    """3D volumetric placeholder."""
+
+    def generate(self, prompt: str) -> Any:
+        raise NotImplementedError("Volume synthesis not implemented")
+
+
+class Video4DModule:
+    """4D video generation placeholder."""
+
+    def generate(self, prompt: str, fps: int = 60) -> Any:
+        raise NotImplementedError("Video synthesis not implemented")
+
+
+# ---------------------------------------------------------------------------
+# OmniModal engine
+# ---------------------------------------------------------------------------
+class OmniModalMiniturbo:
+    """High level facade combining all modalities.
+
+    Each ``generate_*`` method is a stub that represents an expected
+    capability of a hypothetical 4K@60 FPS diffusion system with
+    physics-aware temporal dynamics.  The real implementation would
+    require new models, training data and hardware acceleration.
+    """
+
+    def __init__(self) -> None:
+        self.meta_logic = MetaLogic()
+        self.audio = Audio1DModule()
+        self.image = Image2DModule()
+        self.volume = Volume3DModule()
+        self.video = Video4DModule()
+
+    # -- generation stubs -------------------------------------------------
+    def generate_audio(self, prompt: str) -> bytes:
+        return self.audio.generate(prompt)
+
+    def generate_image(self, prompt: str, resolution: int = 512) -> Any:
+        return self.image.generate(prompt, resolution)
+
+    def generate_volume(self, prompt: str) -> Any:
+        return self.volume.generate(prompt)
+
+    def generate_video(self, prompt: str, fps: int = 60) -> Any:
+        return self.video.generate(prompt, fps)
+
+
+__all__ = ["OmniModalMiniturbo", "MetaLogic"]


### PR DESCRIPTION
## Summary
- draft `OmniModalMiniturbo` placeholder illustrating a 1D/2D/3D/4D diffusion interface
- expose the placeholder through package `__init__`
- document the experimental module in the README

## Testing
- `python -m py_compile web_stable_diffusion/models/miniturbo_omnimodal.py web_stable_diffusion/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a23bfdcf28832dbaccfeb3c6373e0d