### PR TITLE
Ensure RPC debug script includes required imports

### DIFF
--- a/tests/debug/rpc_run.py
+++ b/tests/debug/rpc_run.py
@@ -1,6 +1,6 @@
+import numpy as np
 import os
 import json
-import numpy as np
 import argparse
 from web_stable_diffusion.rpc_testing import WebGPUDebugSession
 


### PR DESCRIPTION
## Summary
- Reordered and ensured presence of numpy, os, json, and argparse imports in RPC debug script

## Testing
- `pytest tests/debug/rpc_run.py -q` *(fails: ModuleNotFoundError: No module named 'web_stable_diffusion')*

------
https://chatgpt.com/codex/tasks/task_e_68bb283cd418832da9946f26140fdbcd