### PR TITLE
Ensure compare_lib imports os, argparse, and List

### DIFF
--- a/tests/debug/compare_lib.py
+++ b/tests/debug/compare_lib.py
@@ -1,7 +1,6 @@
-from typing import List
-
 import argparse
 import os
+from typing import List
 
 import numpy as np
 import tvm


### PR DESCRIPTION
## Summary
- Reorder imports in `tests/debug/compare_lib.py` so standard library modules (`argparse`, `os`) and `List` typing are explicitly imported together

## Testing
- `pytest tests/debug/compare_lib.py` *(fails: ModuleNotFoundError: No module named 'tvm')*

------
https://chatgpt.com/codex/tasks/task_e_68bb283b965c832dbf0cff922c62755a