### PR TITLE
Specify Python 3.8+ requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-  ],
+        "Programming Language :: Python :: 3.8",
+    ],
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
## Summary
- update `setup.py` classifiers to require Python 3.8+
- add `python_requires` to enforce Python interpreter version

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb2841904c832d8972dd4027ecbafe