### PR TITLE
Summarise scheduler benchmarks in omni-modal manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You are also more than welcomed to checkout [Web LLM](https://github.com/mlc-ai/
 > * The neuro-symbolic `OmniModalMiniturbo` engine can now delegate image synthesis to a real [🤗 Diffusers](https://github.com/huggingface/diffusers) pipeline when a model checkpoint is available. Set `OMNIMODAL_DIFFUSERS_MODEL` to a local or remote model identifier and install the optional dependencies (`diffusers`, `torch`, and any scheduler plugins) to enable photorealistic decoding. The symbolic generator remains available as a deterministic fallback for lightweight testing.
 > * Generated manifests are written to a durable SQLite store (`OMNIMODAL_MANIFEST_DB`) so results survive process restarts and can be audited later.
 > * The streaming API now enforces API-key authentication (`X-API-Key`) and fixed-window rate limiting (`OMNIMODAL_RATE_LIMIT`/`OMNIMODAL_RATE_PERIOD`) to make deployments safer on shared infrastructure.
+> * Generated manifests expose a summarised scheduler report (modalities completed, worker utilisation, transport mix) alongside the full benchmark payload so dashboards and tests can reason about concurrency without parsing implementation-specific fields.
 >
 > See [docs/omnimodal.md](docs/omnimodal.md) for the architectural roadmap and additional hardening guidance.
 

--- a/tests/integration/test_api_load.py
+++ b/tests/integration/test_api_load.py
@@ -48,3 +48,6 @@ def test_concurrent_generation_requests_stay_isolated(api_security_env: None) ->
         metrics = manifest.get("metadata", {}).get("metrics", {})
         assert metrics.get("wall_clock_s_total", 0.0) >= 0.0
         assert metrics.get("wall_clock_s_elapsed", 0.0) >= 0.0
+        scheduler = metrics["scheduler"]
+        assert scheduler["modalities_completed"] == 4
+        assert scheduler["worker_count"] >= 1

--- a/tests/test_api_streaming.py
+++ b/tests/test_api_streaming.py
@@ -98,6 +98,10 @@ def test_streaming_api_emits_all_modalities(api_security_env: None) -> None:
     metrics = manifest["metadata"]["metrics"]
     assert metrics["wall_clock_s_total"] >= 0.0
     assert metrics["wall_clock_s_elapsed"] >= 0.0
+    scheduler = metrics["scheduler"]
+    assert scheduler["modalities_completed"] == len(modality_events)
+    assert scheduler["executor"] in {"thread", "process"}
+    assert scheduler["timeline_events"] >= len(modality_events)
 
     manifest_response = client.get(f"/manifests/{token_id}")
     assert manifest_response.status_code == 200

--- a/tests/unit/test_benchmarking.py
+++ b/tests/unit/test_benchmarking.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from web_stable_diffusion.runtime.benchmarking import summarise_benchmark
+
+
+def test_summarise_benchmark_distils_core_metrics() -> None:
+    benchmark = {
+        "executor": "thread",
+        "requested_executor": "auto",
+        "max_workers": 4,
+        "requested_max_workers": 8,
+        "wall_clock_s": 0.42,
+        "makespan_s": 0.42,
+        "modalities_per_s": 9.5,
+        "speedup_vs_serial": 2.1,
+        "worker_utilisation": 0.77,
+        "average_duration_s": 0.12,
+        "completed": 4,
+        "total": 4,
+        "transport_breakdown": {"pinned_memory": 1, "host_transfer": 2, "zero_copy": 1},
+        "resource_summary": {
+            "memory_bytes_peak": 123456,
+            "cpu_seconds_total": 1.68,
+            "completed_modalities": 4,
+        },
+        "executor_state": {
+            "queue_depth_initial": 4,
+            "queue_depth_final": 0,
+            "worker_launches": 4,
+            "peak_in_flight": 3,
+            "policy": "work-stealing",
+        },
+        "timeline": [
+            {"type": "dispatch", "timestamp_s": 0.0},
+            {"type": "complete", "timestamp_s": 0.1},
+            {"type": "complete", "timestamp_s": 0.3},
+        ],
+        "tasks": {
+            "audio": {"dispatch_seq": 0},
+            "image": {"dispatch_seq": 1},
+        },
+    }
+
+    summary = summarise_benchmark(benchmark)
+
+    assert summary["executor"] == "thread"
+    assert summary["requested_executor"] == "auto"
+    assert summary["worker_count"] == 4
+    assert summary["requested_worker_count"] == 8
+    assert summary["modalities_completed"] == 4
+    assert summary["modalities_total"] == 4
+    assert summary["transport_breakdown"] == {
+        "pinned_memory": 1,
+        "host_transfer": 2,
+        "zero_copy": 1,
+    }
+    assert summary["resource_summary"] == {
+        "memory_bytes_peak": 123456.0,
+        "cpu_seconds_total": 1.68,
+        "completed_modalities": 4,
+    }
+    assert summary["executor_state"]["peak_in_flight"] == 3
+    assert summary["timeline_events"] == 3
+    assert 0.29 <= summary["timeline_span_s"] <= 0.3
+    assert summary["tracked_modalities"] == 2

--- a/tests/unit/test_cli_manifest.py
+++ b/tests/unit/test_cli_manifest.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from web_stable_diffusion.cli.omnimodal import _bundle_to_manifest
+from web_stable_diffusion.models.modal_generators import DeviceAwareResult
+
+
+def test_bundle_to_manifest_embeds_scheduler_summary(tmp_path: Path) -> None:
+    bundle = {
+        "image": DeviceAwareResult(
+            backend="numpy",
+            device="cpu",
+            data=np.zeros((2, 2, 3), dtype=np.float32),
+            metadata={"metrics": {"wall_clock_s": 0.5}},
+        )
+    }
+    benchmark = {
+        "executor": "thread",
+        "max_workers": 1,
+        "requested_executor": "auto",
+        "requested_max_workers": None,
+        "completed": 1,
+        "total": 1,
+        "timeline": [],
+        "tasks": {"image": {"dispatch_seq": 0}},
+    }
+
+    manifest = _bundle_to_manifest(
+        bundle,
+        tmp_path,
+        executor="thread",
+        device_backend="numpy",
+        benchmark=benchmark,
+    )
+
+    artifact_path = tmp_path / "image.npz"
+    assert artifact_path.exists()
+
+    metrics = manifest["metadata"]["metrics"]
+    assert metrics["wall_clock_s_total"] == 0.5
+    scheduler = metrics["scheduler"]
+    assert scheduler["executor"] == "thread"
+    assert scheduler["worker_count"] == 1
+    assert scheduler["modalities_completed"] == 1

--- a/web_stable_diffusion/cli/omnimodal.py
+++ b/web_stable_diffusion/cli/omnimodal.py
@@ -19,6 +19,7 @@ from web_stable_diffusion.models.miniturbo_omnimodal import (
     OmniModalMiniturbo,
     ResourceBudget,
 )
+from web_stable_diffusion.runtime.benchmarking import summarise_benchmark
 
 
 def _serialise_payload(array: np.ndarray, output_path: pathlib.Path) -> str:
@@ -100,6 +101,7 @@ def _bundle_to_manifest(
     if benchmark is not None:
         manifest["metadata"]["benchmark"] = benchmark
     total_duration = 0.0
+    metrics_summary: Dict[str, Any] = {}
     for key, result in bundle.items():
         array = result.to_numpy()
         artifact_path = base_dir / f"{key}.npz"
@@ -112,12 +114,18 @@ def _bundle_to_manifest(
             "device": result.device,
             "metadata": result.metadata,
         }
-        metrics = result.metadata.get("metrics") if isinstance(result.metadata, dict) else None
-        if metrics and "wall_clock_s" in metrics:
-            total_duration += float(metrics["wall_clock_s"])
+        modality_metrics = result.metadata.get("metrics") if isinstance(result.metadata, dict) else None
+        if modality_metrics and "wall_clock_s" in modality_metrics:
+            total_duration += float(modality_metrics["wall_clock_s"])
         manifest["artifacts"][key] = entry
-    if total_duration:
-        manifest["metadata"]["metrics"] = {"wall_clock_s_total": total_duration}
+    if total_duration or bundle:
+        metrics_summary["wall_clock_s_total"] = float(total_duration)
+    if benchmark is not None:
+        scheduler = summarise_benchmark(benchmark)
+        if scheduler:
+            metrics_summary["scheduler"] = scheduler
+    if metrics_summary:
+        manifest["metadata"]["metrics"] = metrics_summary
     return manifest
 
 

--- a/web_stable_diffusion/runtime/api.py
+++ b/web_stable_diffusion/runtime/api.py
@@ -31,6 +31,7 @@ from web_stable_diffusion.models.miniturbo_omnimodal import (
     OmniModalMiniturbo,
     ResourceBudget,
 )
+from web_stable_diffusion.runtime.benchmarking import summarise_benchmark
 
 
 logger = logging.getLogger(__name__)
@@ -643,6 +644,11 @@ def _stream_bundle_events(
         return
     else:
         engine_manager.mark_healthy()
+        elapsed = time.perf_counter() - start
+        metrics: Dict[str, Any] = {
+            "wall_clock_s_total": total_wall,
+            "wall_clock_s_elapsed": elapsed,
+        }
         manifest = {
             "artifacts": artifacts,
             "metadata": {
@@ -655,16 +661,14 @@ def _stream_bundle_events(
                     }
                     for key, budget in (budgets or {}).items()
                 },
-                "metrics": {
-                    "wall_clock_s_total": total_wall,
-                    "wall_clock_s_elapsed": time.perf_counter() - start,
-                },
+                "metrics": metrics,
             },
         }
 
         benchmark = getattr(engine, "last_benchmark", None)
         if benchmark:
-            manifest["metadata"]["metrics"]["scalability"] = _normalise_metadata(benchmark)
+            metrics["scheduler"] = summarise_benchmark(benchmark)
+            metrics["scalability"] = _normalise_metadata(benchmark)
 
         manifest_registry.record_complete(token_id, manifest)
         yield json.dumps({"type": "complete", "manifest": manifest}) + "\n"

--- a/web_stable_diffusion/runtime/benchmarking.py
+++ b/web_stable_diffusion/runtime/benchmarking.py
@@ -1,0 +1,149 @@
+"""Utilities for distilling omni-modal execution benchmark metadata."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+__all__ = ["summarise_benchmark"]
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def summarise_benchmark(benchmark: Mapping[str, Any]) -> Dict[str, Any]:
+    """Produce a JSON-serialisable summary of the execution benchmark.
+
+    The omni-modal engine records an extensive benchmark structure that includes
+    scheduling decisions, transport strategies, and resource statistics for each
+    modality.  Persisting the entire payload in manifests can be noisy, so this
+    helper distils the data into a stable subset of metrics that downstream
+    dashboards and tests can rely on.
+    """
+
+    summary: Dict[str, Any] = {}
+
+    float_fields = {
+        "wall_clock_s": "wall_clock_s",
+        "makespan_s": "makespan_s",
+        "modalities_per_s": "modalities_per_s",
+        "speedup_vs_serial": "speedup_vs_serial",
+        "worker_utilisation": "worker_utilisation",
+        "average_duration_s": "average_duration_s",
+    }
+    for source, target in float_fields.items():
+        value = _as_float(benchmark.get(source))
+        if value is not None:
+            summary[target] = value
+
+    completed = _as_int(benchmark.get("completed"))
+    if completed is not None:
+        summary["modalities_completed"] = completed
+    total = _as_int(benchmark.get("total"))
+    if total is not None:
+        summary["modalities_total"] = total
+
+    worker_count = _as_int(benchmark.get("max_workers"))
+    if worker_count is not None:
+        summary["worker_count"] = worker_count
+    requested_workers = _as_int(benchmark.get("requested_max_workers"))
+    if requested_workers is not None:
+        summary["requested_worker_count"] = requested_workers
+
+    executor = benchmark.get("executor")
+    if isinstance(executor, str):
+        summary["executor"] = executor
+    requested_executor = benchmark.get("requested_executor")
+    if isinstance(requested_executor, str):
+        summary["requested_executor"] = requested_executor
+
+    deadline = _as_float(benchmark.get("deadline_s"))
+    if deadline is not None:
+        summary["deadline_s"] = deadline
+
+    for key in ("timed_out", "cancelled", "fallback_to_threads", "supports_cuda_ipc"):
+        value = benchmark.get(key)
+        if isinstance(value, bool):
+            summary[key] = value
+
+    device = benchmark.get("device")
+    if isinstance(device, Mapping):
+        device_summary: Dict[str, Any] = {}
+        backend = device.get("backend")
+        if isinstance(backend, str):
+            device_summary["backend"] = backend
+        device_id = device.get("device")
+        if isinstance(device_id, str):
+            device_summary["device"] = device_id
+        if device_summary:
+            summary["device"] = device_summary
+
+    transport = benchmark.get("transport_breakdown")
+    if isinstance(transport, Mapping):
+        summary["transport_breakdown"] = {
+            "pinned_memory": _as_int(transport.get("pinned_memory")) or 0,
+            "host_transfer": _as_int(transport.get("host_transfer")) or 0,
+            "zero_copy": _as_int(transport.get("zero_copy")) or 0,
+        }
+
+    resource_summary = benchmark.get("resource_summary")
+    if isinstance(resource_summary, Mapping):
+        resources: Dict[str, Any] = {}
+        memory_peak = _as_float(resource_summary.get("memory_bytes_peak"))
+        if memory_peak is not None:
+            resources["memory_bytes_peak"] = memory_peak
+        cpu_total = _as_float(resource_summary.get("cpu_seconds_total"))
+        if cpu_total is not None:
+            resources["cpu_seconds_total"] = cpu_total
+        completed_modalities = _as_int(resource_summary.get("completed_modalities"))
+        if completed_modalities is not None:
+            resources["completed_modalities"] = completed_modalities
+        if resources:
+            summary["resource_summary"] = resources
+
+    executor_state = benchmark.get("executor_state")
+    if isinstance(executor_state, Mapping):
+        state: Dict[str, Any] = {}
+        for key in ("queue_depth_initial", "queue_depth_final", "worker_launches", "peak_in_flight"):
+            value = _as_int(executor_state.get(key))
+            if value is not None:
+                state[key] = value
+        policy = executor_state.get("policy")
+        if isinstance(policy, str):
+            state["policy"] = policy
+        if state:
+            summary["executor_state"] = state
+
+    timeline = benchmark.get("timeline")
+    if isinstance(timeline, list):
+        summary["timeline_events"] = len(timeline)
+        if timeline:
+            timestamps = [
+                _as_float(event.get("timestamp_s"))
+                for event in timeline
+                if isinstance(event, Mapping)
+            ]
+            if timestamps:
+                summary["timeline_span_s"] = max(timestamps) - min(timestamps)
+
+    tasks = benchmark.get("tasks")
+    if isinstance(tasks, Mapping):
+        summary["tracked_modalities"] = len(tasks)
+
+    return summary


### PR DESCRIPTION
## Summary
- add a runtime benchmarking helper that distils omni-modal executor metrics into a stable manifest summary
- expose the scheduler summary in both CLI-generated and streaming API manifests and document the new visibility in the README
- add unit and API tests that validate the scheduler metadata and the helper’s behaviour

## Testing
- pytest tests/unit/test_benchmarking.py tests/unit/test_cli_manifest.py tests/test_api_streaming.py tests/integration/test_api_load.py


------
https://chatgpt.com/codex/tasks/task_e_6901982fc730832d9eb0fb9ebdf5a37d